### PR TITLE
Fix a subscription issue when using cert auth

### DIFF
--- a/pyaci/core.py
+++ b/pyaci/core.py
@@ -30,9 +30,10 @@ import xmltodict
 import sys
 import time
 try:
-    from urllib.parse import unquote
+    from urllib.parse import unquote, urlparse
 except ImportError:
     from urllib import unquote
+    from urlparse import urlparse
 
 from .errors import (
     MetaError, MoError, ResourceError, RestError, UserError
@@ -879,6 +880,31 @@ class AppLoginMethod(Api):
         super(AppLoginMethod, self).__init__(parentApi=parentApi)
         self._moClassName = "aaaAppToken"
         self._properties = {}
+
+    def POST(self, format=None, **kwargs):
+        resp = super(AppLoginMethod, self).POST(format=format, **kwargs)
+
+        if resp is None or resp.status_code != requests.codes.ok:
+            logger.debug('Login failed!')
+            return resp
+
+        if payloadFormat != 'xml' or resp.text[:5] != '<?xml':
+            logger.error('XML format of AppLogin is only supported now')
+            return resp
+
+        # NOTE (2021-02-03, Praveen Kumar): /api/requestAppToken.xml doesn't set
+        # the token in the cookies automatically. Hence, intercept the response
+        # and set the cookie explicitly.
+        doc = xmltodict.parse(resp.text)
+        if 'imdata' in doc:
+            if 'aaaLogin' in doc['imdata']:
+                token = doc['imdata']['aaaLogin']['@token']
+                domain = urlparse(resp.url).netloc.split(':')[0]
+                self._rootApi().session.cookies.set(
+                    'APIC-cookie', token, domain=domain
+                )
+
+        return resp
 
     @property
     def Json(self):


### PR DESCRIPTION
/api/requestAppToken.xml doesn't set the token in the cookies
automatically. Hence, intercept the response and explicitly set the
cookie